### PR TITLE
chore: require CODEOWNER review and up to date branches

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -4,6 +4,8 @@ branchProtectionRules:
 # Identifies the protection rule pattern. Name of the branch to be protected.
 # Defaults to `master`
 - pattern: master
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - 'Kokoro'
     - 'cla/google'


### PR DESCRIPTION
These two lines bring the rules on this repo in line with the defaults:

https://github.com/googleapis/repo-automation-bots/blob/63c858e539e1f4d9bb8ea66e12f9c0a0de5fef55/packages/sync-repo-settings/src/required-checks.json#L40-L50


Fixes #<issue_number_goes_here> 🦕
