### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "containeranalysis",
     "name_pretty": "Cloud Container Analysis",
     "product_documentation": "https://cloud.google.com/container-registry/docs/container-analysis",
-    "client_documentation": "https://googleapis.dev/python/containeranalysis/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/containeranalysis/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559777",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ and retrieval of critical metadata about all of your software artifacts.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-containeranalysis.svg
    :target: https://pypi.org/project/google-cloud-containeranalysis/
 .. _Container Analysis API: https://cloud.google.com/container-registry/docs/container-analysis
-.. _Client Library Documentation: https://googleapis.dev/python/containeranalysis/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/containeranalysis/latest
 .. _Product Documentation:  https://cloud.google.com/container-registry/docs/container-analysis
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.